### PR TITLE
Fix confusing example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,7 @@ $ pip install tinkoff-investments
 - &#9744; Кеширование данных
 - &#9744; Торговая стратегия
 
-## Примеры
-
-Примеры доступны [здесь](https://github.com/Tinkoff/invest-python/tree/main/examples).
+## Как пользоваться
 
 ```python
 from tinkoff.invest import Client
@@ -38,13 +36,10 @@ with Client(TOKEN) as client:
     print(client.users.get_accounts())
 ```
 
-Для запуска примеров, нужно добавить токен в переменную окружения.
+> :warning: **Не публикуйте токены в общедоступные репозитории**
+<br/>
 
-<!-- termynal -->
-
-```
-$ export INVEST_TOKEN=YOUR_TOKEN
-```
+Остальные примеры доступны в [examples](https://github.com/Tinkoff/invest-python/tree/main/examples).
 
 ## Contribution
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,13 @@
+Cначала нужно добавить токен в переменную окружения.
+
+<!-- termynal -->
+
+```console
+$ export INVEST_TOKEN=YOUR_TOKEN
+```
+
+А потом можно запускать примеры
+
+```console
+$ python examples/client.py
+```


### PR DESCRIPTION
1. Избавиться от повторения слова "Пример", а то масло масляное
2. Упростить для понимания reame, путем вынесения нерелевантной информации о примерах в exemples/readme
3. Добавить предупреждение о публикаци токенов
