### PR TITLE
fix: Fix `min() arg is an empty sequence` error on get_all_candles

### DIFF
--- a/tinkoff/invest/services.py
+++ b/tinkoff/invest/services.py
@@ -200,7 +200,7 @@ class MarketDataCache(ICandleGetter):
         net_range: Tuple[datetime, datetime],
     ) -> Iterable[HistoricCandle]:
         candles = list(from_net)
-        if len(candles) > 0:
+        if candles:
             storage.update(
                 [InstrumentDateRangeData(date_range=net_range, historic_candles=candles)]
             )

--- a/tinkoff/invest/services.py
+++ b/tinkoff/invest/services.py
@@ -200,15 +200,16 @@ class MarketDataCache(ICandleGetter):
         net_range: Tuple[datetime, datetime],
     ) -> Iterable[HistoricCandle]:
         candles = list(from_net)
-        storage.update(
-            [InstrumentDateRangeData(date_range=net_range, historic_candles=candles)]
-        )
-        logger.debug("From net [\n%s\n%s\n]", str(net_range[0]), str(net_range[1]))
-        logger.debug(
-            "From net real [\n%s\n%s\n]",
-            str(min(list(map(lambda x: x.time, candles)))),
-            str(max(list(map(lambda x: x.time, candles)))),
-        )
+        if len(candles) > 0:
+            storage.update(
+                [InstrumentDateRangeData(date_range=net_range, historic_candles=candles)]
+            )
+            logger.debug("From net [\n%s\n%s\n]", str(net_range[0]), str(net_range[1]))
+            logger.debug(
+                "From net real [\n%s\n%s\n]",
+                str(min(list(map(lambda x: x.time, candles)))),
+                str(max(list(map(lambda x: x.time, candles)))),
+            )
 
         yield from candles
 


### PR DESCRIPTION
If there are not candles for the period the request fails with `ValueError: min() arg is an empty sequence`.

Which I believe is not expected behaviour