### PR TITLE
fix(ci): skip sandbox tests for non contributors

### DIFF
--- a/tests/test_strategies/test_moving_average/test_trader_in_sandbox.py
+++ b/tests/test_strategies/test_moving_average/test_trader_in_sandbox.py
@@ -18,6 +18,7 @@ from tinkoff.invest import (
     ShareResponse,
     TradingSchedulesResponse,
 )
+from tinkoff.invest.exceptions import UnauthenticatedError
 from tinkoff.invest.services import SandboxService, Services
 from tinkoff.invest.strategies.base.account_manager import AccountManager
 from tinkoff.invest.strategies.base.errors import MarketDataNotAvailableError
@@ -178,6 +179,10 @@ def _ensure_is_market_active(
 @pytest.mark.skipif(
     os.environ.get("INVEST_SANDBOX_TOKEN") is None,
     reason="INVEST_SANDBOX_TOKEN should be specified",
+)
+@pytest.mark.xfail(
+    raises=UnauthenticatedError,
+    reason="INVEST_SANDBOX_TOKEN is incorrect",
 )
 class TestMovingAverageStrategyTraderInSandbox:
     def test_trade(

--- a/tests/test_strategies/test_moving_average/test_trader_on_real_market_data.py
+++ b/tests/test_strategies/test_moving_average/test_trader_on_real_market_data.py
@@ -17,6 +17,7 @@ from tinkoff.invest import (
     PortfolioResponse,
     Quotation,
 )
+from tinkoff.invest.exceptions import UnauthenticatedError
 from tinkoff.invest.services import Services
 from tinkoff.invest.strategies.base.account_manager import AccountManager
 from tinkoff.invest.strategies.moving_average.plotter import (
@@ -219,6 +220,10 @@ def start_datetime() -> datetime:
 @pytest.mark.skipif(
     os.environ.get("INVEST_SANDBOX_TOKEN") is None,
     reason="INVEST_SANDBOX_TOKEN should be specified",
+)
+@pytest.mark.xfail(
+    raises=UnauthenticatedError,
+    reason="INVEST_SANDBOX_TOKEN is incorrect",
 )
 class TestMovingAverageStrategyTraderRealMarketData:
     @pytest.mark.freeze_time()


### PR DESCRIPTION
Скипнул еще падающие тесты у контрибуторов. Им не прикидывается секрет INVEST_SANDBOX_TOKEN. И тут можно как-то попробовать, но пока опять такое решение. Можно локально чекать make test